### PR TITLE
fix: workflow skips execution

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -49,7 +49,8 @@ jobs:
               repo: context.repo.repo,
               body: `
               We have automatically detected the following broken relative paths in your lessons.
-              Please check the file paths and associated broken paths inside them.
+              Please check the file paths and associated broken paths inside them. 
+              Learn more from our [contributing guide](https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md).
               # Check Broken Paths
               ${{ env.BROKEN_PATHS }}
               `
@@ -94,6 +95,7 @@ jobs:
               body: `
               We have automatically detected missing tracking id from the following relative paths in your lessons.
               Please check the file paths and associated paths inside them.
+              Learn more from our [contributing guide](https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md).
               # Check Missing Tracking from Paths
               ${{ env.PATHS_TRACKING }}
               `
@@ -138,6 +140,7 @@ jobs:
               body: `
               We have automatically detected missing tracking id from the following URLs in your lessons.
               Please check the file paths and associated URLs inside them.
+              Learn more from our [contributing guide](https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md).
               # Check Missing Tracking from URLs
               ${{ env.URLS_TRACKING }}
               `
@@ -182,6 +185,7 @@ jobs:
               body: `
               We have automatically detected added country locale to URLs in your lessons.
               Please check the file paths and associated URLs inside them.
+              Learn more from our [contributing guide](https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md).
               # Check Country Locale in URLs
               ${{ env.URLS_LOCALE }}
               `

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -59,6 +59,7 @@ jobs:
         run: exit 1
 
   check-paths-tracking:
+    if: ${{ always() }}
     needs: check-broken-paths
     name: Check Paths Have Tracking
     runs-on: ubuntu-latest
@@ -102,6 +103,7 @@ jobs:
         run: exit 1
 
   check-urls-tracking:
+    if: ${{ always() }}
     needs: check-paths-tracking
     name: Check URLs Have Tracking
     runs-on: ubuntu-latest
@@ -145,6 +147,7 @@ jobs:
         run: exit 1
 
   check-urls-locale:
+    if: ${{ always() }}
     needs: check-urls-tracking
     name: Check URLs Don't Have Locale
     runs-on: ubuntu-latest


### PR DESCRIPTION
the failure of the previous job stopped the next job from executing 
= add check to always run regardless of the previous job status

- add a reference to contributing guidance to the comment.