### PR TITLE
Fixed Missing Notebook links

### DIFF
--- a/07-building-chat-applications/README.md
+++ b/07-building-chat-applications/README.md
@@ -60,7 +60,7 @@ When building a chat application, a great first step is to assess what is alread
 - **Easier maintenance**: Updates and improvements are easier to manage as most APIs and SDKs simply require an update to a library when a newer version is released.
 - **Access to cutting edge technology**: Leveraging models that have been fined tuned and trained on extensive datasets provides your application with natural language capabilities.
 
-Accessing functionality of an SDK or API typically involves obtaining permission to use the provided services, which is often through the use of a unique key or authentication token. We'll use the OpenAI Python Library to explore what this looks like. You can also try it out on your own in the [notebook](./notebook.ipynb?WT.mc_id=academic-105485-koreyst) for this lesson.
+Accessing functionality of an SDK or API typically involves obtaining permission to use the provided services, which is often through the use of a unique key or authentication token. We'll use the OpenAI Python Library to explore what this looks like. You can also try it out on your own in the following [notebook for OpenAI](./notebook-openai.ipynb?WT.mc_id=academic-105485-koreyst) or [notebook for Azure OpenAI Services](./notebook-azure-openai.ipynb?WT.mc_id=academic-105485-koreys) for this lesson.
 
 ```python
 import os

--- a/07-building-chat-applications/translations/cn/README.md
+++ b/07-building-chat-applications/translations/cn/README.md
@@ -62,7 +62,7 @@
 - **更容易维护**：更新和改进更易于管理，因为大多数 API 和 SDK 在发布新版本时只需要更新库。
 - **获得尖端技术**：利用经过微调和在广泛数据集上训练的模型为您的应用程序提供自然语言功能。
 
-访问 SDK 或 API 的功能通常涉及获取使用所提供服务的许可，这通常是通过使用唯一 kwy 或身份验证 token 来实现的。 我们将使用 OpenAI Python library 来探索它是什么样子。 您也可以在本章的[notebook](./notebook.ipynb?WT.mc_id=academic-105485-koreyst) 中自行尝试。
+访问 SDK 或 API 的功能通常涉及获取使用所提供服务的许可，这通常是通过使用唯一 kwy 或身份验证 token 来实现的。 我们将使用 OpenAI Python library 来探索它是什么样子。 您也可以在本章的[OpenAI notebook](./notebook-openai.ipynb?WT.mc_id=academic-105485-koreyst) [Azure OpenAI notebook](./notebook-azure-openai.ipynb?WT.mc_id=academic-105485-koreyst)  中自行尝试。
 
 
 ```python

--- a/07-building-chat-applications/translations/cn/README.md
+++ b/07-building-chat-applications/translations/cn/README.md
@@ -62,7 +62,13 @@
 - **更容易维护**：更新和改进更易于管理，因为大多数 API 和 SDK 在发布新版本时只需要更新库。
 - **获得尖端技术**：利用经过微调和在广泛数据集上训练的模型为您的应用程序提供自然语言功能。
 
-访问 SDK 或 API 的功能通常涉及获取使用所提供服务的许可，这通常是通过使用唯一 kwy 或身份验证 token 来实现的。 我们将使用 OpenAI Python library 来探索它是什么样子。 您也可以在本章的[OpenAI notebook](./notebook-openai.ipynb?WT.mc_id=academic-105485-koreyst) [Azure OpenAI notebook](./notebook-azure-openai.ipynb?WT.mc_id=academic-105485-koreyst)  中自行尝试。
+访问 SDK 或 API 的功能通常涉及获取使用所提供服务的许可，这通常是通过使用唯一 kwy 或身份验证 token 来实现的。 我们将使用 OpenAI Python library 来探索它是什么样子。 您也可以在本章的
+
+[OpenAI notebook](../../notebook-openai.ipynb?WT.mc_id=academic-105485-koreyst) 
+
+[Azure OpenAI notebook](../../notebook-azure-openai.ipynb?WT.mc_id=academic-105485-koreyst)  
+
+中自行尝试。
 
 
 ```python


### PR DESCRIPTION
Fixing Lesson 7 Readme file which was missing links to OpenAI and Azure OpenAI notebooks see https://github.com/microsoft/generative-ai-for-beginners/issues/155

Fix 
You can also try it out on your own in the following [notebook for OpenAI](./notebook-openai.ipynb?WT.mc_id=academic-105485-koreyst) or [notebook for Azure OpenAI Services](./notebook-azure-openai.ipynb?WT.mc_id=academic-105485-koreys) for this lesson.