### PR TITLE
Fixed VSCode hyperlink

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -69,7 +69,7 @@ Refer to this link on creating a [conda environments](https://docs.conda.io/proj
 
 ### Using Visual Studio Code with Python Extension
 
-Probably the best way to use the curriculum is to open it in [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst with [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
+Probably the best way to use the curriculum is to open it in [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) with [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
 
 > **Note**: Once you clone and open the directory in VS Code, it will automatically suggest you to install Python extensions. You would also have to install miniconda as described above.
 


### PR DESCRIPTION
Fixed Visual Studio Code hyperlink on `00-course-setup/README.md`.