### PR TITLE
Fix link for OpenAI signup

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -103,7 +103,7 @@ One of the best ways to keep your API keys secure when using GitHub Codespaces i
 
 The course has 6 concept lessons and 6 coding lessons.
 
-For the coding lessons, we are using the Azure OpenAI Service. You will need access to the Azure OpenAI service and an API key to run this code. You can apply to get access by [completing this application](https://customervoice.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR7en2Ais5pxKtso_Pz4b1_xUOFA5Qk1UWDRBMjg0WFhPMkIzTzhKQ1dWNyQlQCN0PWcu&culture=en-us&country=us&WT.mc_id=academic-105485-koreyst).
+For the coding lessons, we are using the Azure OpenAI Service. You will need access to the Azure OpenAI service and an API key to run this code. You can apply to get access by [completing this application](https://azure.microsoft.com/products/ai-services/openai-service?WT.mc_id=academic-105485-koreyst).
 
 While you wait for your application to be processed, each coding lesson also includes a `README.md` file where you can view the code and outputs.
 


### PR DESCRIPTION
Adding in link to https://azure.microsoft.com/en-us/products/ai-services/openai-service for Azure OpenAI Signup to fix https://github.com/microsoft/generative-ai-for-beginners/issues/190 @