### PR TITLE
Fix azure portal link for ch04

### DIFF
--- a/04-prompt-engineering-fundamentals/README.md
+++ b/04-prompt-engineering-fundamentals/README.md
@@ -33,7 +33,7 @@ The Jupyter Notebook accompanying this lesson provides a _sandbox_ environment w
 
 We have instrumented this repository with a _dev container_ that comes with a Python 3 runtime. Simply open the repo in GitHub Codespaces or on your local Docker Desktop, to activate the runtime automatically. Then open the notebook and select the Python 3.x kernel to prepare the Notebook for execution.
 
-The default notebook is set up for use with an Azure OpenAI service resource. Simply copy the `.env.copy` file in the root of the folder to `.env` and update the `AZURE_OPENAI_API_KEY=` and `AZURE_OPENAI_API_ENDPOINT=` lines with your API key and endpoint. You can check your credentials in the [Azure portal](portal.azure.com), by navigating to your Azure OpenAI resource and then opening the _Keys and Endpoints_ tab in the left menu.
+The default notebook is set up for use with an Azure OpenAI service resource. Simply copy the `.env.copy` file in the root of the folder to `.env` and update the `AZURE_OPENAI_API_KEY=` and `AZURE_OPENAI_API_ENDPOINT=` lines with your API key and endpoint. You can check your credentials in the [Azure portal](https://portal.azure.com?WT.mc_id=academic-105485-koreyst), by navigating to your Azure OpenAI resource and then opening the _Keys and Endpoints_ tab in the left menu.
 Also, please add the name you assigned to your model when you created the deployment to the `AZURE_OPENAI_DEPLOYMENT` variable. The recommended model for this exercise is 'gpt-35-turbo'.
 
 The notebook comes with _starter_ exercises - but you are encouraged to add your own _Markdown_ (description) and _Code_ (prompt requests) sections to try out more examples or ideas - and build your intuition for prompt design.


### PR DESCRIPTION
Hello,
In the [ch04](https://github.com/microsoft/generative-ai-for-beginners/blob/main/04-prompt-engineering-fundamentals/README.md), the `Azure portal` was set as a **relative path**, so it did not access to the webpage properly. I have corrected this. 
Thank you! ☺️