### PR TITLE
Fix Codespaces billing note

### DIFF
--- a/00-course-setup/translations/ja-jp/README.md
+++ b/00-course-setup/translations/ja-jp/README.md
@@ -22,7 +22,7 @@ Codespaces は、フォークしたリポジトリから、下記の緑のボタ
 
 > [!NOTE]
 > (訳者追記)：  
-Fork したリポジトリで Codespace を利用する場合、Codespace の使用料はマイクロソフトが支払います。
+Organization に所属しないユーザーが Fork したリポジトリで Codespace を利用する場合、[Codespace の使用料は個人のアカウントに課金されます](https://docs.github.com/ja/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#limiting-the-number-of-organization-owned-codespaces)。
 
 ### 3. API　キーの保管
 


### PR DESCRIPTION
Unless you belong to the microsoft Organization, Codespace are billed to GitHub for individual account.  
https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#how-billing-is-handled-for-forked-repositories

---

https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md

> Ensure that any URL from the following domains github.com, microsoft.com, visualstudio.com, aka.ms, and azure.com has a tracking ID (i.e. ? or & then wt.mc_id= or WT.mc_id=) at the end of it.

I do not know whose tracking ID to URL, so I have not listed them.

> Ensure that your links don't have country specific locale in them (i.e. /en-us/ or /en/).

Because this is a pull request for a Japanese translated file, I am using `ja` for locale.