### PR TITLE
Chores/fixes

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -5,7 +5,6 @@ on:
   pull_request_target:
     branches: 
       - main
-      - chores/fixes
     paths:
       - '**.md'
       - '**.ipynb'

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -87,7 +87,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   check-broken-urls:
     if: ${{ always() }}
-    needs: check-urls-locale
     name: Check Broken URLs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -99,7 +99,7 @@ jobs:
         id: check-broken-urls
         uses: john0isaac/action-check-markdown@v1.0.6
         with:
-          command: check_borken_urls
+          command: check_broken_urls
           directory: ./
           guide-url: 'https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     branches: 
       - main
+      - chores/fixes
     paths:
       - '**.md'
       - '**.ipynb'
@@ -84,3 +85,22 @@ jobs:
           directory: ./
           guide-url: 'https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+  check-broken-urls:
+    if: ${{ always() }}
+    needs: check-urls-locale
+    name: Check Broken URLs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run Check Broken URLs
+        id: check-broken-urls
+        uses: john0isaac/action-check-markdown@v1.0.6
+        with:
+          command: check_borken_urls
+          directory: ./
+          guide-url: 'https://github.com/microsoft/generative-ai-for-beginners/blob/main/CONTRIBUTING.md'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/04-prompt-engineering-fundamentals/README.md
+++ b/04-prompt-engineering-fundamentals/README.md
@@ -1,6 +1,6 @@
 # Prompt Engineering Fundamentals
 
-[![Prompt Engineering Fundamentals](./images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
+[![Prompt Engineering Fundamentals](./images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
 
 The way your write your prompt to an LLM also matters. A carefully-crafted prompt can achieve a better quality of response. But what exactly do terms like _prompt_ and _prompt engineering_ mean? And how do I improve the prompt _input_ that I send to the LLM? These are the questions we'll try to answer with in this chapter and the next.
 

--- a/04-prompt-engineering-fundamentals/translations/cn/README.md
+++ b/04-prompt-engineering-fundamentals/translations/cn/README.md
@@ -1,6 +1,6 @@
 # 第四章：提示工程基础
 
-[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
+[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
 
 如何撰写 LLM 的提示很重要，精心设计的提示可以比不精心设计的提示取得更好的结果。 但这些概念到底是什么，提示、提示工程以及我如何改进我发送给 LLMs 的内容？ 诸如此类的问题正是本章和下一章想要解答的。
 

--- a/04-prompt-engineering-fundamentals/translations/ja-jp/README.md
+++ b/04-prompt-engineering-fundamentals/translations/ja-jp/README.md
@@ -1,6 +1,6 @@
 # プロンプト・エンジニアリングの基礎
 
-[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-yoterada)](https://learn.microsoft.com/_themes/docs.theme/master/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-yoterada)
+[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-yoterada)](https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
 
 大規模言語モデル (LLM) では、プロンプトの書き方がとても重要で、慎重に作成したプロンプトは、そうでないものに比べ良い結果をもたらします。しかし、プロンプトやプロンプト・エンジニアリングとは一体どういう物なのでしょうか？また、LLM に送信する内容をどのようにして改善すればいいのでしょうか？この章と次の章では、そうした疑問に答えたいと思います。
 

--- a/04-prompt-engineering-fundamentals/translations/pt-br/README.md
+++ b/04-prompt-engineering-fundamentals/translations/pt-br/README.md
@@ -1,6 +1,6 @@
 # Fundamentos de Engenharia de Prompt
 
-[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
+[![Prompt Engineering Fundamentals](../../images/04-lesson-banner.png?WT.mc_id=academic-105485-koreyst)](https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/global/video-embed.html?id=d54c0c69-b183-4a6c-80ed-8b1a8f299cff?WT.mc_id=academic-105485-koreyst)
 
 A forma como você escreve seu prompt para o LLM importa. Um prompt cuidadosamente elaborado pode alcançar um resultado melhor do que um que não é. Mas o que são esses conceitos, prompt, Engenharia de Prompt e como posso melhorar o que envio para o LLM? Perguntas como essas são o que este capítulo e o próximo estão procurando responder.
 

--- a/13-securing-ai-applications/README.md
+++ b/13-securing-ai-applications/README.md
@@ -134,11 +134,11 @@ Below are key insights that have shaped Microsoft’s AI Red Team program.
 3. **Dynamic Nature of AI Systems:**
    AI applications constantly evolve. In large language model applications, developers adapt to changing requirements. Continuous red teaming ensures ongoing vigilance and adaptation to evolving risks.
 
-AI red teaming is not all encompassing and should be consider a complementary motion to additonal controls such as [role-based access control (RBAC)](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control?WT.mc_id=academic-105485-koreyst) and comprehensive data management solutions. It's meant to suppplement a security strategy that focuses on employing safe and responsible AI solutions that account for privacy and security while aspiring to minimize biases, harmful content and misinformaiton that can erode user confidence.
+AI red teaming is not all encompassing and should be consider a complementary motion to additional controls such as [role-based access control (RBAC)](https://learn.microsoft.com/azure/ai-services/openai/how-to/role-based-access-control?WT.mc_id=academic-105485-koreyst) and comprehensive data management solutions. It's meant to suppplement a security strategy that focuses on employing safe and responsible AI solutions that account for privacy and security while aspiring to minimize biases, harmful content and misinformaiton that can erode user confidence.
 
 Here's a list of additional reading that can help you better understand how red teaming can help identify and mitigate risks in your AI systems:
 
-- [Planning red teaming for large language models (LLMs) and their applications](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/red-teaming?WT.mc_id=academic-105485-koreyst)
+- [Planning red teaming for large language models (LLMs) and their applications](https://learn.microsoft.com/azure/ai-services/openai/concepts/red-teaming?WT.mc_id=academic-105485-koreyst)
 - [What is the OpenAI Red Teaming Network?](https://openai.com/blog/red-teaming-network?WT.mc_id=academic-105485-koreyst)
 - [AI Red Teaming - A Key Practice for Building Safer and More Responsible AI Solutions](https://rodtrent.substack.com/p/ai-red-teaming?WT.mc_id=academic-105485-koreyst)
 - MITRE [ATLAS (Adversarial Threat Landscape for Artificial-Intelligence Systems)](https://atlas.mitre.org/?WT.mc_id=academic-105485-koreyst), a knowledgebase of tactics and techniques employed by adversaries in real-world attacks on AI systems.
@@ -155,7 +155,7 @@ A:1, While all three are great recommendations, ensuring that you're assigning t
 
 ## 🚀 Challenge
 
-Read up more on how you can [govern and protect sensitive information](https://learn.microsoft.com/en-us/training/paths/purview-protect-govern-ai/?WT.mc_id=academic-105485-koreyst) in the age of AI.
+Read up more on how you can [govern and protect sensitive information](https://learn.microsoft.com/training/paths/purview-protect-govern-ai/?WT.mc_id=academic-105485-koreyst) in the age of AI.
 
 ## Great Work, Continue Your Learning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ instructions provided by the bot. You will only need to do this once across all 
 
 ## Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information read the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/?WT.mc_id=academic-105485-koreyst).
+For more information read the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/?WT.mc_id=academic-105485-koreyst) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Question or Problem?
 
@@ -59,7 +59,7 @@ To make sure that your links are working properly simply use VS code to check th
 
 For example, when you hover over any link in your files you will be prompted to follow the link by pressing on **ctrl + click**
 
-![VS code follow links screenshot](./images/vscode-follow-link.png "Screenshot from vs code prompt to follow a link when you hover over a link.")
+![VS code follow links screenshot](./images/vscode-follow-link.png?WT.mc_id=academic-105485-koreyst "Screenshot from vs code prompt to follow a link when you hover over a link.")
 
 If you click on a link and it's not working locally then, surely it will trigger the workflow and won't work on GitHub.
 
@@ -67,7 +67,7 @@ To fix this issue, try to type the link with the help of VS code.
 
 When you type `./` or `../` VS code will prompt you to choose from the available options according to what you typed.
 
-![VS code select relative path screenshot](./images/vscode-select-relative-path.png "Screenshot from vs code prompt to select relative path from a pop up list.")
+![VS code select relative path screenshot](./images/vscode-select-relative-path.png?WT.mc_id=academic-105485-koreyst "Screenshot from vs code prompt to select relative path from a pop up list.")
 
 Follow the path by clicking on the desired file or folder and you will be sure that your path is not broken.
 
@@ -84,7 +84,7 @@ If it's appended to your relative paths then you will pass this check.
 
 If not, you may get the following error.
 
-![GitHub check paths missing tracking comment screenshot](./images/github-check-paths-missing-tracking-comment.png "Screenshot from github comment that shows missing tracking from relative paths")
+![GitHub check paths missing tracking comment screenshot](./images/github-check-paths-missing-tracking-comment.png?WT.mc_id=academic-105485-koreyst "Screenshot from github comment that shows missing tracking from relative paths")
 
 To fix this issue, try to open the file path that the workflow highlighted and add the tracking ID to the end of the relative paths.
 
@@ -101,7 +101,7 @@ If it's appended to your URLs then you will pass this check.
 
 If not, you may get the following error.
 
-![GitHub check urls missing tracking comment screenshot](./images/github-check-urls-missing-tracking-comment.png "Screenshot from github comment that shows missing tracking from urls")
+![GitHub check urls missing tracking comment screenshot](./images/github-check-urls-missing-tracking-comment.png?WT.mc_id=academic-105485-koreyst "Screenshot from github comment that shows missing tracking from urls")
 
 To fix this issue, try to open the file path that the workflow highlighted and add the tracking ID to the end of the URLs.
 
@@ -118,7 +118,7 @@ If it's not present in your URLs then you will pass this check.
 
 If not, you may get the following error.
 
-![GitHub check country locale comment screenshot](./images/github-check-country-locale-comment.png "Screenshot from github comment that shows added country locale to urls")
+![GitHub check country locale comment screenshot](./images/github-check-country-locale-comment.png?WT.mc_id=academic-105485-koreyst "Screenshot from github comment that shows added country locale to urls")
 
 To fix this issue, try to open the file path that the workflow highlighted and remove the country locale from the URLs.
 


### PR DESCRIPTION
- Add new functionality to check broken internet urls.
- fix issues with embed videos and security blogs.

fix #322 

I just noticed that if we remove country locale from embedded video URLs it doesn't work.

I released a new patch of the [markdown-checker](https://github.com/john0isaac/markdown-checker) to fix this issue by skipping the URLs that have `video-embed.html` at the end of it.

This PR is to fix the rest of the links that still have country locale and will work if we remove them.

cc: @leestott for notification QA.