### PR TITLE
docs: :memo: Updating references to openapi python package from 0.28 …

### DIFF
--- a/04-prompt-engineering-fundamentals/README.md
+++ b/04-prompt-engineering-fundamentals/README.md
@@ -199,7 +199,7 @@ Now let's add context and instructions to that basic prompt. The [Chat Completio
 The request is now in the form below, where the _tokenization_ effectively captures relevant information from context and conversation. Now, changing the system context can be as impactful on the quality of completions, as the user inputs provided.
 
 ```python
-response = openai.ChatCompletion.create(
+response = openai.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},

--- a/04-prompt-engineering-fundamentals/translations/cn/README.md
+++ b/04-prompt-engineering-fundamentals/translations/cn/README.md
@@ -194,7 +194,7 @@ Illustrated with examples.
 该请求现在采用以下形式，其中标记化有效地从上下文和对话中捕获相关信息。 现在，更改系统上下文对补全质量的影响并与提供的用户输入一样。
 
 ```python
-response = openai.ChatCompletion.create(
+response = openai.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},

--- a/04-prompt-engineering-fundamentals/translations/ja-jp/README.md
+++ b/04-prompt-engineering-fundamentals/translations/ja-jp/README.md
@@ -219,7 +219,7 @@ CONCEPT #2:
 実際のリクエストは下記のようになります。トークン化によってシステム・コンテキストと会話履歴から関連情報を効果的に捉えられるようになります。システム・コンテキストの変更は、利用者の入力内容と同じくらい、回答品質に影響を与える可能性があります。
 
 ```python
-response = openai.ChatCompletion.create(
+response = openai.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "あなたは頼りになる助手です。"},

--- a/04-prompt-engineering-fundamentals/translations/ko/README.md
+++ b/04-prompt-engineering-fundamentals/translations/ko/README.md
@@ -194,7 +194,7 @@ Illustrated with examples.
 아래의 요청은 _토큰화_ 를 통해 맥락과 대화에서 관련 정보를 효과적으로 포착합니다. 이제 시스템 맥락을 변경하는 것은 사용자 입력과 마찬가지로 완성 품질에 큰 영향을 미칠 수 있습니다.
 
 ```python
-response = openai.ChatCompletion.create(
+response = openai.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},

--- a/04-prompt-engineering-fundamentals/translations/pt-br/README.md
+++ b/04-prompt-engineering-fundamentals/translations/pt-br/README.md
@@ -196,7 +196,7 @@ Agora, vamos adicionar contexto e instruções a esse prompt básico. A [API de 
 A solicitação agora está na forma abaixo, onde a _tokenização_ captura efetivamente informações relevantes do contexto e da conversa. Agora, alterar o contexto do sistema pode ter um impacto significativo na qualidade dos completamentos, assim como as entradas do usuário fornecidas.
 
 ```python
-response = openai.ChatCompletion.create(
+response = openai.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
         {"role": "system", "content": "Você é um assistente prestativo."},


### PR DESCRIPTION
…to 1 in Chapter 4

With OpenAPI Python package upgraded from 0.28 to 1.0, there are changes in the API. Specifically relevant to this chapter is the chat completions api.  Since the quoted MS Learn resources point to 1.0 version, hence this update.