### PR TITLE
Fix typo in "Qdrant"

### DIFF
--- a/15-rag-and-vector-databases/README.md
+++ b/15-rag-and-vector-databases/README.md
@@ -84,7 +84,7 @@ A vector database, unlike traditional databases, is a specialized database desig
 
 We store our embeddings in vector databases as LLMs have a limit of the number of tokens they accept as input. As you cannot pass the entire embeddings to an LLM, we will need to break them down into chunks and when a user asks a question, the embeddings most like the question will be returned together with the prompt. Chunking also reduces costs on the number of tokens passed through an LLM.
 
-Some popular vector databases include Azure Cosmos DB, Clarifyai, Pinecone, Chromadb, ScaNN,, Quadrants and DeepLake. You can create an Azure Cosmos DB model using Azure CLI with the following command:
+Some popular vector databases include Azure Cosmos DB, Clarifyai, Pinecone, Chromadb, ScaNN, Qdrant and DeepLake. You can create an Azure Cosmos DB model using Azure CLI with the following command:
 
 ```bash
 az login


### PR DESCRIPTION
"Quadrants" isn't the correct name of the vector database. 