### PR TITLE
fix the typo from Image to images of OpenAIClient

### DIFF
--- a/09-building-image-applications/python/aoai-app.py
+++ b/09-building-image-applications/python/aoai-app.py
@@ -60,7 +60,7 @@ finally:
 # ---creating variation below---
 
 
-response = client.Image.create_variation(
+response = client.images.create_variation(
   image=open(image_path, "rb"),
   n=1,
   size="1024x1024"


### PR DESCRIPTION
fix typo from client.Image.create_variation to client.images.create_variation