### PR TITLE
Update the numpy version to 1.26.4 to fix ImpImporter error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipywidgets==7.7.1
 matplotlib==3.7.0
-numpy==1.24.2
+numpy==1.26.4
 pandas==1.5.3
 tqdm==4.66.3
 python-dotenv==1.0.0


### PR DESCRIPTION
Update the numpy version to 1.26.4 to fix ImpImporter error from the 'pkgutil,ImpImporter' attribute, which has been removed in Python 3.12 in Windows 11 (python 3.12) using venv.