### PR TITLE
use https instead of http for vscode urls

### DIFF
--- a/.devcontainer/Setup.txt
+++ b/.devcontainer/Setup.txt
@@ -5,4 +5,4 @@ such as the Python extension and the Jupyter.
 Finally, it will run the command pip install -r requirements.txt after the container is 
 created, which will install all the Python libraries listed in the requirements.txt file. 
 You can learn more about how to create and use dev containers in VS Code from this link or this link. 
-I hope this helps you with your project http://code.visualstudio.com?WT.mc_id=academic-105485-koreyst 
+I hope this helps you with your project https://code.visualstudio.com?WT.mc_id=academic-105485-koreyst 

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -75,7 +75,7 @@ Refer to the [Conda environments guide](https://docs.conda.io/projects/conda/en/
 
 ### Using Visual Studio Code with the Python support extension
 
-We recommend using the [Visual Studio Code (VS Code)](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) editor with the [Python support extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst) installed for this course. This is, however, more of a recommendation and not a definite requirement
+We recommend using the [Visual Studio Code (VS Code)](https://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) editor with the [Python support extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst) installed for this course. This is, however, more of a recommendation and not a definite requirement
 
 > **Note**: By opening the course repository in VS Code, you have the option to set the project up within a container. This is because of the [special `.devcontainer`](https://code.visualstudio.com/docs/devcontainers/containers?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst) directory found within the course repository. More on this later.
 

--- a/00-course-setup/translations/cn/README.md
+++ b/00-course-setup/translations/cn/README.md
@@ -39,7 +39,7 @@ conda activate ai4beg
 
 ### 使用 Visual Studio Code Python 插件
 
-学习本课程，建议使用 [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-77998-bethanycheum) 的 [Python 插件](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-77998-bethanycheum).
+学习本课程，建议使用 [Visual Studio Code](https://code.visualstudio.com/?WT.mc_id=academic-77998-bethanycheum) 的 [Python 插件](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-77998-bethanycheum).
 
 > **注意**：在 VS Code 中克隆并打开该目录后，会自动建议您安装 Python 插件。 还必须如上所述要求安装 miniconda。
 

--- a/00-course-setup/translations/es-mx/README.md
+++ b/00-course-setup/translations/es-mx/README.md
@@ -72,7 +72,7 @@ si encuentras algún problema.
 ### Usando Visual Studio Code con la Extensión de Python
 
 
-Probablemente la mejor manera de usar el plan de estudios sea abrirlo en [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) con [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
+Probablemente la mejor manera de usar el plan de estudios sea abrirlo en [Visual Studio Code](https://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) con [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
 
 > **Nota**: Una vez que clones y abras el directorio en VS Code, automáticamente te sugerirá instalar las extensiones de Python. También tendrás que instalar Miniconda como se describe arriba.
 

--- a/00-course-setup/translations/ja-jp/README.md
+++ b/00-course-setup/translations/ja-jp/README.md
@@ -72,7 +72,7 @@ conda activate ai4beg
 
 ### Python の拡張機能をインストールした Visual Studio Code の使用
 
-このカリキュラムを進める際には、[Python の拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-yoterada)をインストールした [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-yoterada) の使用を特にお勧めします。
+このカリキュラムを進める際には、[Python の拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-yoterada)をインストールした [Visual Studio Code](https://code.visualstudio.com/?WT.mc_id=academic-105485-yoterada) の使用を特にお勧めします。
 
 > **ご注意**: クローンした後、VS Code でディレクトリを開くと、自動的に Python 拡張機能のインストールが提案されます。上記で説明したように miniconda もインストールしてください。
 

--- a/00-course-setup/translations/ko/README.md
+++ b/00-course-setup/translations/ko/README.md
@@ -68,7 +68,7 @@ conda activate ai4beg
 
 ### 파이썬 Extension과 함께 Visual Studio Code 사용하기
 
-Probably the best way to use the curriculum is to open it in [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) with [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
+Probably the best way to use the curriculum is to open it in [Visual Studio Code](https://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) with [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
 
 > **Note**: “VS Code에서 디렉토리를 클론하고 열면 자동으로 Python 확장을 설치하라는 제안이 나타납니다. 또한 위에서 설명한대로 miniconda도 설치해야 합니다.
 

--- a/00-course-setup/translations/pt-br/README.md
+++ b/00-course-setup/translations/pt-br/README.md
@@ -68,7 +68,7 @@ Se você tiver problemas, consulte este link sobre a criação de [ambientes con
 
 ### Usando o Visual Studio Code com a Extensão do Python
 
-Provavelmente a melhor maneira de usar o currículo é abrindo no [Visual Studio Code](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) com a [Extensão Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
+Provavelmente a melhor maneira de usar o currículo é abrindo no [Visual Studio Code](https://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst) com a [Extensão Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst).
 
 > **Observação**: Uma vez que você clonar e abrir o diretório no VS Code, ele automaticamente vai sugerir que você instale as extensões do Python. Você também precisará instalar o `Miniconda` conforme descrito acima.
 

--- a/00-course-setup/translations/tw/README.md
+++ b/00-course-setup/translations/tw/README.md
@@ -73,7 +73,7 @@ conda activate ai4beg
 
 ### 使用 Visual Studio Code 搭配 Python 支援擴充功能
 
-我們建議在本課程中使用安裝了[Python 支援擴充功能](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst)的[Visual Studio Code (VS Code)](http://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst)編輯器。不過，這只是建議，並不是絕對的要求。
+我們建議在本課程中使用安裝了[Python 支援擴充功能](https://marketplace.visualstudio.com/items?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst)的[Visual Studio Code (VS Code)](https://code.visualstudio.com/?WT.mc_id=academic-105485-koreyst)編輯器。不過，這只是建議，並不是絕對的要求。
 
 > **注意**: 通過在 VS Code 中打開課程儲存庫，你可以選擇在容器中設定專案。這是因為在課程儲存庫中發現的[特殊 `.devcontainer`](https://code.visualstudio.com/docs/devcontainers/containers?itemName=ms-python.python&WT.mc_id=academic-105485-koreyst)目錄。更多內容稍後介紹。
 


### PR DESCRIPTION
The markdown-checker action doesn't handle http to https redirection which may flag these urls as broken since vscode enforces https.