### PR TITLE
Fix missing distutils module error during build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,8 +17,11 @@
 			"extensions": [
 				"ms-python.python",
 				"ms-toolsai.jupyter"
-			], 
-			"postCreateCommand": "pip3 --disable-pip-version-check --no-cache-dir install -r requirements.txt"
+			],
+			"postCreateCommand": [
+				"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+				"pip3 --disable-pip-version-check --no-cache-dir install -r requirements.txt"
+			]
 		}
 	}
 }


### PR DESCRIPTION
While trying to spawn the devcontainer in VSCode and Codespace, I encountered an error during the build process related to the missing `distutils` package for some reason.

After investigating further,~~I discovered that the build tool failed to read the configuration from the `.devcontainer/environment.yml` file.~~ (after have another look this file is for conda to use but the build doesn't use conda at all) it was using a base Python version higher than 3.10, which is deprecated and no longer includes the distutils package as outlined in [PEP-632 ](https://peps.python.org/pep-0632/). Also, some packages already included in the container image.

This pull request addresses this issue by removing some dependencies instead and add rust compiler to satisfy tiktoken requirement.

Please have a look.

EDIT: change the approach since I couldn't reproduce the build anymore.