### PR TITLE
Fix broken image path in translations/ko/README.md

### DIFF
--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -1,4 +1,4 @@
-![생성형 AI 입문자를 위한 과정](./images/repo-thumbnailv4-fixed.png?WT.mc_id=academic-105485-koreyst)
+![생성형 AI 입문자를 위한 과정](../../images/repo-thumbnailv4-fixed.png?WT.mc_id=academic-105485-koreyst)
 
 ### 생성형 AI 애플리케이션 개발에 필요한 모든 것을 가르치는 21개의 강의
 


### PR DESCRIPTION
- Fixed the image path in the `translations/ko/README.md` to resolve display issues.
  <img width="558" alt="Screenshot 2025-02-22 at 4 23 18 PM" src="https://github.com/user-attachments/assets/36504fb9-eb30-4d5d-b60f-f5725fa95b9e" />
