### PR TITLE
Fixed the environment.yml file

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -104,11 +104,14 @@ Go ahead and populate your environment file with the snippet below:
 name: <environment-name>
 channels:
  - defaults
+ - microsoft
 dependencies:
 - python=<python-version>
 - openai
 - python-dotenv
-- microsoft azure-ai-ml
+- pip
+- pip:
+    - azure-ai-ml
 
 ```
 


### PR DESCRIPTION
Solves the issue #696 

## Issue
I faced a error while following startup guide, azure-ai-ml could not be installed with the following error message:
```
PackagesNotFoundError: The following packages are not available from current channels:
microsoft==azure-ai-ml
```
## Root Cause
The current environment.yml file has incorrect syntax for specifying the Microsoft package. The file currently uses:
```yml
name: <environment-name>
channels:
 - defaults
dependencies:
- python=<python-version>
- openai
- python-dotenv
- microsoft azure-ai-ml
```
The issue is with microsoft azure-ai-ml. This isn't valid conda syntax and is likely trying to combine the channel and package name incorrectly.

## Solution
I've updated the environment.yml file to properly install the azure-ai-ml package through pip, which is the recommended approach for this package:
```yml
name: <environment-name>
channels:
  - defaults
  - microsoft
dependencies:
  - python=<python-version>
  - openai
  - python-dotenv
  - pip
  - pip:
      - azure-ai-ml
 ```
This approach correctly adds the Microsoft channel and uses pip to install the azure-ai-ml package, which resolves the installation error.

## Testing
I've verified that this updated configuration successfully creates the environment without the PackagesNotFoundError.
