### PR TITLE
Add Co-op Translator GitHub Action to branch-based push (no PR)

### DIFF
--- a/.github/workflows/co-op-translator.yml
+++ b/.github/workflows/co-op-translator.yml
@@ -1,0 +1,64 @@
+name: Co-op Translator
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  co-op-translator:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Co-op Translator
+        run: |
+          python -m pip install --upgrade pip
+          pip install co-op-translator
+
+      - name: Run Co-op Translator
+        env:
+          PYTHONIOENCODING: utf-8
+          # Azure AI Service Credentials
+          AZURE_SUBSCRIPTION_KEY: ${{ secrets.AZURE_SUBSCRIPTION_KEY }}
+          AZURE_AI_SERVICE_ENDPOINT: ${{ secrets.AZURE_AI_SERVICE_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_MODEL_NAME: ${{ secrets.AZURE_OPENAI_MODEL_NAME }}
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_ORG_ID: ${{ secrets.OPENAI_ORG_ID }}
+          OPENAI_CHAT_MODEL_ID: ${{ secrets.OPENAI_CHAT_MODEL_ID }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+        run: |
+          translate -l "all" -y
+
+      - name: Authenticate GitHub App
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Push to update-translations branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B update-translations
+          git add translations/ translated_images/ || true
+          DATE=$(date -u +'%Y-%m-%d')
+          git diff --cached --quiet || git commit -m "🌐 Update translations on ${DATE} via Co-op Translator"
+          git push https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }} update-translations --force


### PR DESCRIPTION
This PR introduces a branch-based GitHub Action workflow for Co-op Translator, replacing the previous PR-based automation.

## What's changed?
Instead of automatically creating a pull request, Co-op Translator now:

- Pushes translation updates directly to the `update-translations` branch

- Skips PR creation to avoid CLA (Contributor License Agreement) issues with GitHub Apps

- Commits include the UTC date for traceability

    (Commit ex: `🌐 Update translations on YYYY-MM-DD via Co-op Translator`)

## Why this change?
GitHub App-generated PRs cannot pass the Microsoft CLA check, which blocks merges even for automated translation updates.
To ensure compliance while preserving automation, we’ve moved to a push-only model - contributors can manually open PRs from the update-translations branch when ready.


## Workflow Overview
Below is a visual summary of the branch-based workflow:


- GitHub Actions bot pushes to update-translations
- Contributors review + open PRs manually
- CLA passes as PR is authored by a human

![branch-based-pr2](https://github.com/user-attachments/assets/ba1ebb9f-aa16-428f-95e6-6d3c209b678b)
![branch-based-pr](https://github.com/user-attachments/assets/de00bc4a-33ad-4864-8256-6bf5dc965ab5)
