### PR TITLE
Remove unneeded req.txt

### DIFF
--- a/04-prompt-engineering-fundamentals/python/requirements.txt
+++ b/04-prompt-engineering-fundamentals/python/requirements.txt
@@ -1,3 +1,3 @@
-openai==1.55.1
+openai==1.55.3
 python-dotenv==1.0.1
 tiktoken==0.4.0

--- a/04-prompt-engineering-fundamentals/python/requirements.txt
+++ b/04-prompt-engineering-fundamentals/python/requirements.txt
@@ -1,3 +1,0 @@
-openai==1.55.3
-python-dotenv==1.0.1
-tiktoken==0.4.0


### PR DESCRIPTION
The requirement.txt file in this sub-folder doesn't seem necessary. It also contains an outdated version of `openai` that caused the following error when running the notebooks:

`TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`

