### PR TITLE
Exclude translations folder from markdown validation workflow

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**.md'
       - '**.ipynb'
+    paths-ignore:
+      - 'translations/**'
+      - 'translated_images/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🛠️ What’s Changed

This pull request updates the `validate-markdown.yml` workflow to **exclude translation-specific directories** from triggering markdown validation checks.

### 🔄 Changes
- Added `paths-ignore` rule to prevent triggering the workflow when only the following folders are modified:
  - `translations/**`
  - `translated_images/**`

### ✅ Why
These folders contain localized markdown and translated images that are frequently updated in bulk. Running validation jobs (e.g., broken link checks, path tracking) on them:
- Generates excessive noise
- Flags non-critical issues
- Slows down review cycles

By excluding these directories, we reduce false positives and streamline the PR validation process.

> ℹ️ Note: Translated markdown files are regenerated by Co-op Translator whenever the original content changes.  
> This includes updated links, so there is no need to validate translated files manually.
