### PR TITLE
feat: update itens to use variable like parameters

### DIFF
--- a/07-building-chat-applications/python/aoai-assigment-simple.ipynb
+++ b/07-building-chat-applications/python/aoai-assigment-simple.ipynb
@@ -20,7 +20,7 @@
     "assert RESOURCE_ENDPOINT, \"ERROR: Azure OpenAI Endpoint is missing\"\n",
     "assert \"openai.azure.com\" in RESOURCE_ENDPOINT.lower(), \"ERROR: Azure OpenAI Endpoint should be in the form: \\n\\n\\t<your unique endpoint identifier>.openai.azure.com\"\n",
     "openai.api_base = RESOURCE_ENDPOINT\n",
-    "deployment = \"gpt-35-turbo\" # replace with your deployment name"
+    "deployment = os.environ['AZURE_OPENAI_DEPLOYMENT'] # replace with your deployment name"
    ]
   },
   {

--- a/07-building-chat-applications/python/aoai-assigment-simple.ipynb
+++ b/07-building-chat-applications/python/aoai-assigment-simple.ipynb
@@ -20,7 +20,7 @@
     "assert RESOURCE_ENDPOINT, \"ERROR: Azure OpenAI Endpoint is missing\"\n",
     "assert \"openai.azure.com\" in RESOURCE_ENDPOINT.lower(), \"ERROR: Azure OpenAI Endpoint should be in the form: \\n\\n\\t<your unique endpoint identifier>.openai.azure.com\"\n",
     "openai.api_base = RESOURCE_ENDPOINT\n",
-    "deployment = os.environ['AZURE_OPENAI_DEPLOYMENT'] # replace with your deployment name"
+    "deployment = os.environ['AZURE_OPENAI_DEPLOYMENT']"
    ]
   },
   {

--- a/08-building-search-applications/python/aoai-assignment.ipynb
+++ b/08-building-search-applications/python/aoai-assignment.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "text = 'the quick brown fox jumped over the lazy dog'\n",
-    "model = 'text-embedding-ada-002'\n",
+    "model = os.getenv("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT")\n",
     "\n",
     "client.embeddings.create(input = [text], model=model).data[0].embedding"
    ]


### PR DESCRIPTION
This pull request updates environment variable usage in two Jupyter notebooks to improve configurability and align with best practices. Specifically, it replaces hardcoded deployment names with environment variables.

### Updates to environment variable usage:

* In `07-building-chat-applications/python/aoai-assigment-simple.ipynb`, replaced the hardcoded deployment name `"gpt-35-turbo"` with the environment variable `os.environ['AZURE_OPENAI_DEPLOYMENT']` for better flexibility.
* In `08-building-search-applications/python/aoai-assignment.ipynb`, replaced the hardcoded model name `'text-embedding-ada-002'` with the environment variable `os.getenv("AZURE_OPENAI_EMBEDDINGS_DEPLOYMENT")` to support dynamic configuration.