### PR TITLE
Add Generative AI for Beginners using Java to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Our team produces other courses! Check out:
 - [AI Agents for Beginners](https://github.com/microsoft/ai-agents-for-beginners?WT.mc_id=academic-105485-koreyst)
 - [Generative AI for Beginners using .NET](https://github.com/microsoft/Generative-AI-for-beginners-dotnet?WT.mc_id=academic-105485-koreyst)
 - [Generative AI for Beginners using JavaScript](https://aka.ms/genai-js-course?WT.mc_id=academic-105485-koreyst)
+- [Generative AI for Beginners using Java](https://aka.ms/genaijava?WT.mc_id=academic-105485-koreyst)
 - [ML for Beginners](https://aka.ms/ml-beginners?WT.mc_id=academic-105485-koreyst)
 - [Data Science for Beginners](https://aka.ms/datascience-beginners?WT.mc_id=academic-105485-koreyst)
 - [AI for Beginners](https://aka.ms/ai-beginners?WT.mc_id=academic-105485-koreyst)


### PR DESCRIPTION
Included a new course link for 'Generative AI for Beginners using Java' in the list of related resources in the README.