### PR TITLE
Fix broken link for "Setup an LLM Provider" in Lesson 00 Course Setup

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -31,7 +31,7 @@ In your fork: **Code -> Codespaces -> New on main**
 |---------------------|-------------------------------------------------------------------------|
 | Start Lesson 1      | [`01-introduction-to-genai`](../01-introduction-to-genai/README.md)     |
 | Work offline        | [`setup-local.md`](02-setup-local.md)                                   |
-| Setup an LLM Provider | [`providers.md`](providers.md)                                        |
+| Setup an LLM Provider | [`providers.md`](03-providers.md)                                        |
 | Meet other learners | [Join our Discord](https://aka.ms/genai-discord?WT.mc_id=academic-105485-koreyst)   |
 
 ## Troubleshooting


### PR DESCRIPTION
<img width="2539" height="339" alt="image" src="https://github.com/user-attachments/assets/4133fb43-0054-468e-9008-549a830f5b3a" />
