### PR TITLE
Standardize “Other Courses” section using Co-op Translator template

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Our team produces other courses! Check out:
 ---
  
 ### Generative AI Series
-[![Generative AI for Beginners](https://img.shields.io/badge/Generative%20AI%20for%20Beginners-8B5CF6?style=for-the-badge&labelColor=E5E7EB&color=8B5CF6)](https://aka.ms/genai-beginners?WT.mc_id=academic-105485-koreyst)
-[![Generative AI (.NET)](https://img.shields.io/badge/Generative%20AI%20(.NET)-9333EA?style=for-the-badge&labelColor=E5E7EB&color=9333EA)](https://aka.ms/genainet?WT.mc_id=academic-105485-koreyst)
-[![Generative AI (Java)](https://img.shields.io/badge/Generative%20AI%20(Java)-C084FC?style=for-the-badge&labelColor=E5E7EB&color=C084FC)](https://aka.ms/genai-js-course?WT.mc_id=academic-105485-koreyst)
+[![Generative AI for Beginners](https://img.shields.io/badge/Generative%20AI%20for%20Beginners-8B5CF6?style=for-the-badge&labelColor=E5E7EB&color=8B5CF6)](https://github.com/microsoft/generative-ai-for-beginners?WT.mc_id=academic-105485-koreyst)
+[![Generative AI (.NET)](https://img.shields.io/badge/Generative%20AI%20(.NET)-9333EA?style=for-the-badge&labelColor=E5E7EB&color=9333EA)](https://github.com/microsoft/Generative-AI-for-beginners-dotnet?WT.mc_id=academic-105485-koreyst)
+[![Generative AI (Java)](https://img.shields.io/badge/Generative%20AI%20(Java)-C084FC?style=for-the-badge&labelColor=E5E7EB&color=C084FC)](https://github.com/microsoft/generative-ai-for-beginners-java?WT.mc_id=academic-105485-koreyst)
 [![Generative AI (JavaScript)](https://img.shields.io/badge/Generative%20AI%20(JavaScript)-E879F9?style=for-the-badge&labelColor=E5E7EB&color=E879F9)](https://github.com/microsoft/generative-ai-with-javascript?WT.mc_id=academic-105485-koreyst)
 
 ---


### PR DESCRIPTION
### Overview

The “Other Courses” section across the Microsoft Beginners repositories has used slightly different course lists over time.

Since many of the *Beginners* repositories already use [**Co-op Translator**](https://github.com/Azure/Co-op-Translator) for translation synchronization, the same tool now automatically manages the **“Other Courses”** section through a shared template.  
This ensures every repository remains up to date whenever new courses are introduced.

---

### Update details

- Adopted the unified [**other_courses.md** template](https://github.com/Azure/co-op-translator/blob/main/src/co_op_translator/templates/other_courses.md)  
- Once merged, future updates to the shared template will automatically propagate whenever Co-op Translator runs, ensuring that the “Other Courses” section stays current across all repositories

If any course additions or badge style changes are needed in the future, please refer to:  
📘 [How to update the “Other Courses” list](https://github.com/Azure/co-op-translator/blob/main/getting_started/update-other-courses.md)

---

### Benefits

- ✅ Consistent structure across all *Beginners* repositories  
- 🔄 Automatically updated through Co-op Translator runs  
- 🎨 Distinct color badges for better course recognition and accessibility  
