### PR TITLE
Update unit 15 README.md to clarify retrieval options

### DIFF
--- a/15-rag-and-vector-databases/README.md
+++ b/15-rag-and-vector-databases/README.md
@@ -133,9 +133,7 @@ There are several ways to perform search within our database such as:
 
 - **Keyword search** - used for text searches
 
-- **Semantic search** - uses the semantic meaning of words
-
-- **Vector search** - converts documents from text to vector representations using embedding models. Retrieval will be done by querying the documents whose vector representations are closest to the user question.
+- **Vector search** - converts documents from text to vector representations using embedding models, permitting a **semantic search** using the meaning of words. Retrieval will be done by querying the documents whose vector representations are closest to the user question.
 
 - **Hybrid** - a combination of both keyword and vector search.
 


### PR DESCRIPTION
The passage defines "semantic search" and "vector search" as separate options, then immediately describes vector search in a way that makes it the implementation of semantic search. Then it defines "hybrid" as combining keyword and vector, but if semantic and vector were truly distinct, hybrid should be keyword + semantic + vector (three things), not two.

The passage mixes two concepts: search purpose (lexical and semantic) and search implementation (keyword and vector).

The proposed edit resolves this and makes clear that vector search is the alternative to keywoard search (in this list of options), and the reason one might use vector search is to perform a search based on semantics. This also resolves the issue with the hybrid option, which previously made it seem like hybrid didn't support semantic search as an option.