### PR TITLE
fix unit 15 README.md final example code bug

### DIFF
--- a/15-rag-and-vector-databases/README.md
+++ b/15-rag-and-vector-databases/README.md
@@ -208,7 +208,7 @@ def chatbot(user_input):
     # create a message object
     messages=[
         {"role": "system", "content": "You are an AI assistant that helps with AI questions."},
-        {"role": "user", "content": history[-1]}
+        {"role": "user", "content": "\n\n".join(history) }
     ]
 
     # use chat completion to generate a response


### PR DESCRIPTION
Final example in unit 15 appears to have a bug. The python code retrieves relevant chunks and appends to history[], then finally appends the user query to history[], but then only sends the last entry of history[] (the user query) to the LLM. This means the RAG steps do not benefit the LLM query. I'm not sure the intent of the history[-1] line, but I am certain the intent is not what the code currently does. I made a reasonable assumption that the code would be closer or equal to the author's intent if the full history[] were joined and sent to the LLM.