### PR TITLE
Add AgentMarket - B2A Marketplace for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,5 @@ If you get stuck or have any questions about building AI apps. Join fellow learn
 If you have product feedback or errors while building visit:
 
 [![Microsoft Foundry Developer Forum](https://img.shields.io/badge/GitHub-Microsoft_Foundry_Developer_Forum-blue?style=for-the-badge&logo=github&color=000000&logoColor=fff)](https://aka.ms/foundry/forum)
+
+- [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, real energy data (28M+ records), discovery API, LangChain/MCP integration.


### PR DESCRIPTION
Adding AgentMarket.cloud - the first B2A marketplace where AI agents buy from AI agents.

- 189+ listings
- Real energy data (28M+ records)
- API discovery, LangChain, MCP integration

https://agentmarket.cloud