### PR TITLE
docs: fix punctuation in Getting Help section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Our team produces other courses! Check out:
 
 ## Getting Help
 
-If you get stuck or have any questions about building AI apps. Join fellow learners and experienced developers in discussions about MCP. It's a supportive community where questions are welcome and knowledge is shared freely.
+If you get stuck or have any questions about building AI apps, Join fellow learners and experienced developers in discussions about MCP. It's a supportive community where questions are welcome and knowledge is shared freely.
 
 [![Microsoft Foundry Discord](https://dcbadge.limes.pink/api/server/nTYy5BXMWG)](https://discord.gg/nTYy5BXMWG)
 


### PR DESCRIPTION
Minor punctuation fix - changed period to comma for better sentence flow in the Getting Help section.