### PR TITLE
chore: fix typos in GitHub Actions workflow files

### DIFF
--- a/.github/workflows/welcome-issue.yml
+++ b/.github/workflows/welcome-issue.yml
@@ -1,4 +1,4 @@
-name:  Welcome to the Microsoft Generative AI
+name: Welcome to the Microsoft Generative AI
 on:
   # Trigger the workflow on new issue
   issues:
@@ -7,7 +7,7 @@ permissions:
   contents: read
   issues: write
 jobs:
-  asses-issue:
+  assess-issue:
     runs-on: ubuntu-latest
     steps:
       - name: Add Label and thanks comment to Issue

--- a/.github/workflows/welcome-pr.yml
+++ b/.github/workflows/welcome-pr.yml
@@ -27,7 +27,7 @@ jobs:
               repo: context.repo.repo,
               body: `👋 Thanks for contributing @${ issueAuthor }! We will review the pull request and get back to you soon.`
             })
-      - name: Auto-assign issue
+      - name: Auto-assign pull request
         uses: pozil/auto-assign-issue@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix job name typo `asses-issue` → `assess-issue` in `welcome-issue.yml`
- Remove extra whitespace in workflow name in `welcome-issue.yml`
- Fix misleading step name "Auto-assign issue" → "Auto-assign pull request" in `welcome-pr.yml` (this step runs in the PR workflow, not the issue workflow)

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Confirm no functional behavior changes (only cosmetic/naming fixes)
