### PR TITLE
Fix opencode contact link in course setup

### DIFF
--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -220,9 +220,8 @@ Important: when translating text in this repo, please ensure that you do not use
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/?WT.mc_id=academic-105485-koreyst). For more information read the Code of Conduct FAQ or contact [Email opencode](opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/?WT.mc_id=academic-105485-koreyst). For more information read the Code of Conduct FAQ or contact [Email opencode](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Let's Get Started
 
 Now that you have completed the needed steps to complete this course, let's get started by getting an [introduction to Generative AI and LLMs](../01-introduction-to-genai/README.md?WT.mc_id=academic-105485-koreyst).
-


### PR DESCRIPTION
## Summary\n- update the opencode contact link to use `mailto:`\n\n## Why\n- without `mailto:`, the link is treated as a relative path and is not clickable as an email contact