### PR TITLE
docs: restore missing tracking links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,9 +295,9 @@ npm run convert
 ## Additional Resources
 
 - [Course Setup Guide](./00-course-setup/README.md?WT.mc_id=academic-105485-koreyst)
-- [Contributing Guidelines](./CONTRIBUTING.md)
-- [Code of Conduct](./CODE_OF_CONDUCT.md)
-- [Security Policy](./SECURITY.md)
+- [Contributing Guidelines](./CONTRIBUTING.md?WT.mc_id=academic-105485-koreyst)
+- [Code of Conduct](./CODE_OF_CONDUCT.md?WT.mc_id=academic-105485-koreyst)
+- [Security Policy](./SECURITY.md?WT.mc_id=academic-105485-koreyst)
 - [Azure AI Discord](https://aka.ms/genai-discord?WT.mc_id=academic-105485-koreyst)
 - [Collection of Advanced Code Samples](https://aka.ms/genai-beg-code?WT.mc_id=academic-105485-koreyst)
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ If you are looking for more advanced code samples, check out our [collection of 
 
 Join our [official Azure AI Foundry Discord server](https://aka.ms/genai-discord?WT.mc_id=academic-105485-koreyst) to meet and network with other learners taking this course and get support.
 
-Ask questions or share product feedback in our [Azure AI Foundry Developer Forum](https://aka.ms/azureaifoundry/forum) on Github.
+Ask questions or share product feedback in our [Azure AI Foundry Developer Forum](https://aka.ms/azureaifoundry/forum?WT.mc_id=academic-105485-koreyst) on Github.
 
 ## 🚀 Building a Startup?
 
-Visit [Microsoft for Startups](https://www.microsoft.com/startups) to find out how to get started building with Azure credits today.
+Visit [Microsoft for Startups](https://www.microsoft.com/startups?WT.mc_id=academic-105485-koreyst) to find out how to get started building with Azure credits today.
 
 ## 🙏 Want to help?
 
@@ -133,7 +133,7 @@ Our team produces other courses! Check out:
 
 <!-- CO-OP TRANSLATOR OTHER COURSES START -->
 ### LangChain
-[![LangChain4j for Beginners](https://img.shields.io/badge/LangChain4j%20for%20Beginners-22C55E?style=for-the-badge&&labelColor=E5E7EB&color=0553D6)](https://aka.ms/langchain4j-for-beginners)
+[![LangChain4j for Beginners](https://img.shields.io/badge/LangChain4j%20for%20Beginners-22C55E?style=for-the-badge&&labelColor=E5E7EB&color=0553D6)](https://aka.ms/langchain4j-for-beginners?WT.mc_id=academic-105485-koreyst)
 [![LangChain.js for Beginners](https://img.shields.io/badge/LangChain.js%20for%20Beginners-22C55E?style=for-the-badge&labelColor=E5E7EB&color=0553D6)](https://aka.ms/langchainjs-for-beginners?WT.mc_id=m365-94501-dwahlin)
 [![LangChain for Beginners](https://img.shields.io/badge/LangChain%20for%20Beginners-22C55E?style=for-the-badge&labelColor=E5E7EB&color=0553D6)](https://github.com/microsoft/langchain-for-beginners?WT.mc_id=m365-94501-dwahlin)
 ---
@@ -179,4 +179,4 @@ If you get stuck or have any questions about building AI apps. Join fellow learn
 
 If you have product feedback or errors while building visit:
 
-[![Microsoft Foundry Developer Forum](https://img.shields.io/badge/GitHub-Microsoft_Foundry_Developer_Forum-blue?style=for-the-badge&logo=github&color=000000&logoColor=fff)](https://aka.ms/foundry/forum)
+[![Microsoft Foundry Developer Forum](https://img.shields.io/badge/GitHub-Microsoft_Foundry_Developer_Forum-blue?style=for-the-badge&logo=github&color=000000&logoColor=fff)](https://aka.ms/foundry/forum?WT.mc_id=academic-105485-koreyst)


### PR DESCRIPTION
Docs-only update to restore missing tracking links.

Validation:
- verified as a docs-only branch
- pushed branch ix/docs-missing-tracking-links to the fork
- no code changes or test runs required beyond content review