### PR TITLE
docs: fix 'Command Pallete' typo in course setup (VS Code feature is 'Command Palette')

### DIFF
--- a/00-course-setup/01-setup-cloud.md
+++ b/00-course-setup/01-setup-cloud.md
@@ -32,7 +32,7 @@ This takes **~2 minutes** the first time.
 
 ### Option A Codespaces Secrets — Recommended
 
-1. ⚙️ Gear icon -> Command Pallete-> Codespaces : Manage user secret -> Add a new secret.
+1. ⚙️ Gear icon -> Command Palette-> Codespaces : Manage user secret -> Add a new secret.
 2. Name: OPENAI_API_KEY
 3. Value: paste your key → Add secret
 

--- a/00-course-setup/README.md
+++ b/00-course-setup/README.md
@@ -22,7 +22,7 @@ In your fork: **Code -> Codespaces -> New on main**
 
 #### 2.1 Add a secret
 
-1. ⚙️ Gear icon -> Command Pallete-> Codespaces : Manage user secret -> Add a new secret.
+1. ⚙️ Gear icon -> Command Palette-> Codespaces : Manage user secret -> Add a new secret.
 2. Name OPENAI_API_KEY, paste your key, Save.
 
 ### 3.  What’s next?


### PR DESCRIPTION
## What

Fixes a typo in two files under `00-course-setup/`:

> `Command Pallete` → `Command Palette`

## Why

The [VS Code feature](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) is spelled **Command Palette** (two T's), not "Pallete". This appears twice in the English course-setup instructions:

- `00-course-setup/README.md`
- `00-course-setup/01-setup-cloud.md`

Users who search the VS Code docs for "Command Pallete" get no results, which makes the setup step confusing for new learners.

## Note on translations

The same typo has propagated to all 44 translated versions of these files via the Co-op Translator bot. I've only fixed the English source in this PR; once merged, the bot can regenerate the translations from the corrected source on its next scheduled run. Happy to open a follow-up PR cascading the fix to all 44 `translations/*/00-course-setup/` folders if you'd prefer not to wait for regeneration — just let me know.

## Testing

- No code changes — documentation only.
- Diff is literally two `Pallete` → `Palette` replacements.
