### PR TITLE
fix: resolve broken links and typos in Spanish translation

### DIFF
--- a/translations/es/00-course-setup/README.md
+++ b/translations/es/00-course-setup/README.md
@@ -22,7 +22,7 @@ En tu fork: **Code -> Codespaces -> New on main**
 
 #### 2.1 Añade un secreto
 
-1. ⚙️ Icono de engranaje -> Command Pallete -> Codespaces : Manage user secret -> Add a new secret.
+1. ⚙️ Icono de engranaje -> Command Palette -> Codespaces : Manage user secret -> Add a new secret.
 2. Nombre OPENAI_API_KEY, pega tu clave, guarda.
 
 ### 3. ¿Qué sigue?
@@ -179,7 +179,7 @@ Una vez que accedas a la URL, deberías ver el esquema del curso y poder navegar
 
 ### Ejecutando en un contenedor
 
-Una alternativa a configurar todo en tu computadora o Codespace es usar un [contenedor](../../../00-course-setup/<https:/en.wikipedia.org/wiki/Containerization_(computing)?WT.mc_id=academic-105485-koreyst>). La carpeta especial `.devcontainer` dentro del repositorio del curso permite que VS Code configure el proyecto dentro de un contenedor. Fuera de Codespaces, esto requerirá la instalación de Docker, y francamente, implica algo de trabajo, por lo que recomendamos esta opción solo a quienes tienen experiencia trabajando con contenedores.
+Una alternativa a configurar todo en tu computadora o Codespace es usar un [contenedor](https://en.wikipedia.org/wiki/Containerization_(computing)?WT.mc_id=academic-105485-koreyst). La carpeta especial `.devcontainer` dentro del repositorio del curso permite que VS Code configure el proyecto dentro de un contenedor. Fuera de Codespaces, esto requerirá la instalación de Docker, y francamente, implica algo de trabajo, por lo que recomendamos esta opción solo a quienes tienen experiencia trabajando con contenedores.
 
 Una de las mejores maneras de mantener seguras tus claves API cuando usas GitHub Codespaces es usando los Secrets de Codespace. Por favor, sigue la guía [Gestión de secrets en Codespaces](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-secrets-for-your-codespaces?WT.mc_id=academic-105485-koreyst) para aprender más al respecto.
 

--- a/translations/es/19-slm/README.md
+++ b/translations/es/19-slm/README.md
@@ -158,7 +158,7 @@ Aquí algunas características clave de NVIDIA NIM:
 
 NIM forma parte de NVIDIA AI Enterprise, cuyo objetivo es simplificar el despliegue y la operacionalización de modelos de IA, asegurando que funcionen de manera eficiente en GPUs NVIDIA.
 
-- Demo: Uso de Nividia NIM para llamar a Phi-3.5-Vision-API [[Haz clic en este enlace](python/Phi-3-Vision-Nividia-NIM.ipynb)]
+- Demo: Uso de NVIDIA NIM para llamar a Phi-3.5-Vision-API [[Haz clic en este enlace](python/Phi-3-Vision-Nividia-NIM.ipynb)]
 
 
 ### Inferencia Phi-3/3.5 en entorno local


### PR DESCRIPTION
## Summary
Fixes broken links and typos in the Spanish (es) translation:

- **Broken link**: Fix malformed URL in `00-course-setup/README.md` — the containerization Wikipedia link was incorrectly mixing a relative path with an angle-bracketed HTTP URL
- **Typo**: Fix "Nividia" → "NVIDIA" in `19-slm/README.md`
- **Typo**: Fix "Command Pallete" → "Command Palette" in `00-course-setup/README.md`

## Testing
- Verified all linked URLs resolve correctly
- No code changes — markdown only