### PR TITLE
fix(ch06): guard against IndexError on empty LLM choices list

### DIFF
--- a/06-text-generation-apps/python/aoai-app-recipe.py
+++ b/06-text-generation-apps/python/aoai-app-recipe.py
@@ -69,7 +69,7 @@ completion = client.chat.completions.create(model=deployment, messages=messages,
 
 # print response
 print("Recipes:")
-if not completion.choices:
+if not completion.choices or completion.choices[0].message is None:
     print("No response received.")
 else:
     old_prompt_result = completion.choices[0].message.content
@@ -82,6 +82,6 @@ else:
 
     # print response
     print("\n=====Shopping list ======= \n")
-    if completion.choices:
+    if completion.choices and completion.choices[0].message is not None:
         print(completion.choices[0].message.content)
 

--- a/06-text-generation-apps/python/aoai-app-recipe.py
+++ b/06-text-generation-apps/python/aoai-app-recipe.py
@@ -82,6 +82,8 @@ else:
 
     # print response
     print("\n=====Shopping list ======= \n")
-if completion.choices and completion.choices[0].message is not None and completion.choices[0].message.content is not None:
-    print(completion.choices[0].message.content)
+    if completion.choices and completion.choices[0].message is not None and completion.choices[0].message.content is not None:
+        print(completion.choices[0].message.content)
+    else:
+        print("No response received.")
 

--- a/06-text-generation-apps/python/aoai-app-recipe.py
+++ b/06-text-generation-apps/python/aoai-app-recipe.py
@@ -69,16 +69,19 @@ completion = client.chat.completions.create(model=deployment, messages=messages,
 
 # print response
 print("Recipes:")
-print(completion.choices[0].message.content)
+if not completion.choices:
+    print("No response received.")
+else:
+    old_prompt_result = completion.choices[0].message.content
+    print(old_prompt_result)
 
-old_prompt_result = completion.choices[0].message.content
-prompt_shopping = "Produce a shopping list, and please don't include ingredients that I already have at home: "
+    prompt_shopping = "Produce a shopping list, and please don't include ingredients that I already have at home: "
+    new_prompt = f"Given ingredients at home {ingredients} and these generated recipes: {old_prompt_result}, {prompt_shopping}"
+    messages = [{"role": "user", "content": new_prompt}]
+    completion = client.chat.completions.create(model=deployment, messages=messages, max_tokens=600, temperature=0)
 
-new_prompt = f"Given ingredients at home {ingredients} and these generated recipes: {old_prompt_result}, {prompt_shopping}"
-messages = [{"role": "user", "content": new_prompt}]
-completion = client.chat.completions.create(model=deployment, messages=messages, max_tokens=600, temperature=0)
-
-# print response
-print("\n=====Shopping list ======= \n")
-print(completion.choices[0].message.content)
+    # print response
+    print("\n=====Shopping list ======= \n")
+    if completion.choices:
+        print(completion.choices[0].message.content)
 

--- a/06-text-generation-apps/python/aoai-app-recipe.py
+++ b/06-text-generation-apps/python/aoai-app-recipe.py
@@ -82,6 +82,6 @@ else:
 
     # print response
     print("\n=====Shopping list ======= \n")
-    if completion.choices and completion.choices[0].message is not None:
-        print(completion.choices[0].message.content)
+if completion.choices and completion.choices[0].message is not None and completion.choices[0].message.content is not None:
+    print(completion.choices[0].message.content)
 

--- a/06-text-generation-apps/python/aoai-app.py
+++ b/06-text-generation-apps/python/aoai-app.py
@@ -23,7 +23,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/aoai-app.py
+++ b/06-text-generation-apps/python/aoai-app.py
@@ -23,7 +23,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.

--- a/06-text-generation-apps/python/aoai-history-bot.py
+++ b/06-text-generation-apps/python/aoai-history-bot.py
@@ -29,7 +29,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages, temperature=0)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.

--- a/06-text-generation-apps/python/aoai-history-bot.py
+++ b/06-text-generation-apps/python/aoai-history-bot.py
@@ -29,7 +29,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages, temperature=0)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/aoai-study-buddy.py
+++ b/06-text-generation-apps/python/aoai-study-buddy.py
@@ -32,7 +32,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/aoai-study-buddy.py
+++ b/06-text-generation-apps/python/aoai-study-buddy.py
@@ -32,7 +32,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.

--- a/06-text-generation-apps/python/githubmodels-app.py
+++ b/06-text-generation-apps/python/githubmodels-app.py
@@ -33,4 +33,5 @@ response = client.complete(
     top_p=1.    
 )
 
-print(response.choices[0].message.content)
+if response.choices:
+    print(response.choices[0].message.content)

--- a/06-text-generation-apps/python/githubmodels-app.py
+++ b/06-text-generation-apps/python/githubmodels-app.py
@@ -33,5 +33,5 @@ response = client.complete(
     top_p=1.    
 )
 
-if response.choices:
+if response.choices and response.choices[0].message is not None:
     print(response.choices[0].message.content)

--- a/06-text-generation-apps/python/oai-app-recipe.py
+++ b/06-text-generation-apps/python/oai-app-recipe.py
@@ -24,16 +24,19 @@ completion = client.chat.completions.create(model=deployment, messages=messages,
 
 # print response
 print("Recipes:")
-print(completion.choices[0].message.content)
+if not completion.choices:
+    print("No response received.")
+else:
+    old_prompt_result = completion.choices[0].message.content
+    print(old_prompt_result)
 
-old_prompt_result = completion.choices[0].message.content
-prompt_shopping = "Produce a shopping list, and please don't include ingredients that I already have at home: "
+    prompt_shopping = "Produce a shopping list, and please don't include ingredients that I already have at home: "
+    new_prompt = f"Given ingredients at home {ingredients} and these generated recipes: {old_prompt_result}, {prompt_shopping}"
+    messages = [{"role": "user", "content": new_prompt}]
+    completion = client.chat.completions.create(model=deployment, messages=messages, max_tokens=600, temperature=0)
 
-new_prompt = f"Given ingredients at home {ingredients} and these generated recipes: {old_prompt_result}, {prompt_shopping}"
-messages = [{"role": "user", "content": new_prompt}]
-completion = client.chat.completions.create(model=deployment, messages=messages, max_tokens=600, temperature=0)
-
-# print response
-print("\n=====Shopping list ======= \n")
-print(completion.choices[0].message.content)
+    # print response
+    print("\n=====Shopping list ======= \n")
+    if completion.choices:
+        print(completion.choices[0].message.content)
 

--- a/06-text-generation-apps/python/oai-app-recipe.py
+++ b/06-text-generation-apps/python/oai-app-recipe.py
@@ -24,7 +24,7 @@ completion = client.chat.completions.create(model=deployment, messages=messages,
 
 # print response
 print("Recipes:")
-if not completion.choices:
+if not completion.choices or completion.choices[0].message is None:
     print("No response received.")
 else:
     old_prompt_result = completion.choices[0].message.content
@@ -37,6 +37,6 @@ else:
 
     # print response
     print("\n=====Shopping list ======= \n")
-    if completion.choices:
+    if completion.choices and completion.choices[0].message is not None:
         print(completion.choices[0].message.content)
 

--- a/06-text-generation-apps/python/oai-app.py
+++ b/06-text-generation-apps/python/oai-app.py
@@ -16,7 +16,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/oai-app.py
+++ b/06-text-generation-apps/python/oai-app.py
@@ -16,7 +16,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.

--- a/06-text-generation-apps/python/oai-history-bot.py
+++ b/06-text-generation-apps/python/oai-history-bot.py
@@ -24,7 +24,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages, temperature=0)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.

--- a/06-text-generation-apps/python/oai-history-bot.py
+++ b/06-text-generation-apps/python/oai-history-bot.py
@@ -24,7 +24,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages, temperature=0)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/oai-study-buddy.py
+++ b/06-text-generation-apps/python/oai-study-buddy.py
@@ -27,7 +27,8 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 #  very unhappy _____.
 

--- a/06-text-generation-apps/python/oai-study-buddy.py
+++ b/06-text-generation-apps/python/oai-study-buddy.py
@@ -27,7 +27,7 @@ messages = [{"role": "user", "content": prompt}]
 completion = client.chat.completions.create(model=deployment, messages=messages)
 
 # print response
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 #  very unhappy _____.


### PR DESCRIPTION
## Problem

Nine example scripts in chapter 06 call `choices[0].message.content` without checking whether the API returned any choices. This raises a bare `IndexError` when:

- the LLM applies a **content-policy filter** and returns `choices=[]`
- a **token limit** is hit before the first choice is generated
- the API returns a non-standard error response body

These are tutorial scripts that learners copy and run — an `IndexError` here is confusing and makes the example look broken.

## Changes

| File | Fix |
|------|-----|
| `aoai-app.py` | `if completion.choices:` before printing |
| `aoai-history-bot.py` | same |
| `aoai-study-buddy.py` | same |
| `oai-app.py` | same |
| `oai-history-bot.py` | same |
| `oai-study-buddy.py` | same |
| `githubmodels-app.py` | `if response.choices:` before printing |
| `aoai-app-recipe.py` | guard both `choices` accesses; skip dependent shopping-list call when first response is empty |
| `oai-app-recipe.py` | same |

All changes are minimal defensive checks — no logic changes for successful API responses.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*