### PR TITLE
bump markdown-checker to 1.3.1

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Check broken Paths
         id: check-broken-paths
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_paths
           directory: ./
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Run Check paths tracking
         id: check-paths-tracking
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_paths_tracking
           directory: ./
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Run Check URLs Country Locale
         id: check-urls-locale
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_urls_locale
           directory: ./
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Run Check Broken URLs
         id: check-broken-urls
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_urls
           directory: ./


### PR DESCRIPTION
I recently used zizmor to audit the package and fixed all the issues it flagged.

This update includes:
- Sticky comments, only one comment will be posted per command used instead of spamming the pull request with every push.
- zizmor security fixes.
- Only posting comments to pull requests for push we update summary of job and mark it as failed/succeed.
- I pinned `markdown-checker` the python package behind this tool since I saw unpinned dependencies causing lots of issues everywhere.
- Due to `pull_request: write` GitHub restrictions it's no longer required since commenting won't work unless the pull request is not from a fork. only updating the summary and GitHub annotations.

For more info check: https://markdown-checker.readthedocs.io/en/latest/howto/github-actions/