### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/06-text-generation-apps/README.md
+++ b/06-text-generation-apps/README.md
@@ -205,6 +205,8 @@ Now that we learned how to set up and configure openai, it's time to build your 
    > [!NOTE]
    > If you're using plain OpenAI (not Azure), use `client = OpenAI(api_key="<replace this value with your OpenAI key>")` (no `base_url`) and pass a model name like `gpt-5-mini` instead of a deployment name.
 
+> The same OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=generative-ai-for-beginners&utm_content=text-generation-apps) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).
+
    You should see an output like the following:
 
    ```output

--- a/06-text-generation-apps/README.md
+++ b/06-text-generation-apps/README.md
@@ -205,7 +205,7 @@ Now that we learned how to set up and configure openai, it's time to build your 
    > [!NOTE]
    > If you're using plain OpenAI (not Azure), use `client = OpenAI(api_key="<replace this value with your OpenAI key>")` (no `base_url`) and pass a model name like `gpt-5-mini` instead of a deployment name.
 
-> The same OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=generative-ai-for-beginners&utm_content=text-generation-apps) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).
+> The same OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1` (`OpenAI(api_key=..., base_url="https://api.daoxe.com/v1")`).
 
    You should see an output like the following:
 


### PR DESCRIPTION
## Summary

Clarify that the OpenAI Python client `base_url` pattern works with OpenAI-compatible multi-model gateways when not using the default provider endpoint, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render
- [ ] Existing examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>