### PR TITLE
fix(python): reject whitespace-only values in env_utils

### DIFF
--- a/shared/python/env_utils.py
+++ b/shared/python/env_utils.py
@@ -26,7 +26,7 @@ def get_required_env(var_name: str, description: str | None = None) -> str:
         >>> api_key = get_required_env("OPENAI_API_KEY", "OpenAI API authentication")
     """
     value = os.getenv(var_name)
-    if not value:
+    if not value or not value.strip():
         desc_part = f" ({description})" if description else ""
         raise ValueError(
             f"Missing required environment variable: {var_name}{desc_part}. "
@@ -57,7 +57,7 @@ def validate_env_vars(*var_names: str) -> dict[str, str]:
 
     for var_name in var_names:
         value = os.getenv(var_name)
-        if not value:
+        if not value or not value.strip():
             missing.append(var_name)
         else:
             values[var_name] = value
@@ -83,6 +83,6 @@ def get_env_with_default(var_name: str, default: str) -> str:
         The value of the environment variable or the default.
 
     Example:
-        >>> model = get_env_with_default("MODEL_NAME", "gpt-4o")
+        >>> model = get_env_with_default("AZURE_OPENAI_DEPLOYMENT", "gpt-5-mini")
     """
     return os.getenv(var_name, default)

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -26,6 +26,12 @@ def test_get_required_env_empty_raises(monkeypatch):
         get_required_env("EMPTY_VAR")
 
 
+def test_get_required_env_whitespace_only_raises(monkeypatch):
+    monkeypatch.setenv("WHITESPACE_VAR", "   ")
+    with pytest.raises(ValueError, match="WHITESPACE_VAR"):
+        get_required_env("WHITESPACE_VAR")
+
+
 def test_get_required_env_includes_description(monkeypatch):
     monkeypatch.delenv("NEEDS_DESC", raising=False)
     with pytest.raises(ValueError, match="OpenAI authentication"):
@@ -47,6 +53,13 @@ def test_validate_env_vars_reports_all_missing(monkeypatch):
     message = str(exc_info.value)
     assert "VAR_X" in message
     assert "VAR_Y" in message
+
+
+def test_validate_env_vars_rejects_whitespace_only(monkeypatch):
+    monkeypatch.setenv("VAR_A", "valid")
+    monkeypatch.setenv("VAR_B", "  ")
+    with pytest.raises(ValueError, match="VAR_B"):
+        validate_env_vars("VAR_A", "VAR_B")
 
 
 def test_get_env_with_default_uses_default(monkeypatch):


### PR DESCRIPTION
Treat blank or whitespace-only environment variables as missing in get_required_env and validate_env_vars, and add pytest coverage.
