### PR TITLE
Bump Node.js to 22 in code-quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install ESLint
         run: npm install --no-save eslint@8 @typescript-eslint/parser @typescript-eslint/eslint-plugin


### PR DESCRIPTION
This pull request updates the Node.js version used in the code quality workflow to ensure compatibility with newer features and dependencies.

Workflow environment update:

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L88-R88): Upgraded the Node.js version from 20 to 22 in the setup step.