### PR TITLE
[Lesson 17] Add a remote MCP web tools exercise

### DIFF
--- a/17-ai-agents/README.md
+++ b/17-ai-agents/README.md
@@ -196,6 +196,10 @@ async def main():
         url="https://search.parallel.ai/mcp",
         load_prompts=False,
         request_timeout=60,
+        # Use the text payload once; the server also returns it as structured content.
+        parse_tool_results=lambda result: "\n".join(
+            content.text for content in result.content if content.type == "text"
+        ),
     ) as web:
         print("Available tools:", [tool.name for tool in web.functions])
 
@@ -205,9 +209,7 @@ async def main():
             search_queries=["Microsoft Learn what are AI agents"],
             session_id=session_id,
         )
-        for content in search:
-            if content.type == "text":
-                print(content.text)
+        print(search)
 
         page = await web.call_tool(
             "web_fetch",
@@ -215,9 +217,7 @@ async def main():
             objective="Explain what Agent Framework does.",
             session_id=session_id,
         )
-        for content in page:
-            if content.type == "text":
-                print(content.text)
+        print(page)
 
 
 asyncio.run(main())

--- a/17-ai-agents/README.md
+++ b/17-ai-agents/README.md
@@ -167,6 +167,66 @@ client = OpenAIChatClient(
 )
 ```
 
+### Try a remote MCP tool
+
+With a local function such as `get_weather`, you define the tool's inputs yourself. With **Model Context Protocol (MCP)**, a server supplies tool descriptions and input schemas, and the framework turns them into callable tools. You can inspect and call those tools before giving them to an agent.
+
+This optional exercise uses [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) to search the public web and extract page text over Streamable HTTP. Its anonymous endpoint requires no Parallel account or API key; free access is rate limited. Running the example sends its search query, requested URL, objectives, and session identifier to Parallel. Use public information, not secrets or private documents.
+
+In your Python environment, install the framework and its optional MCP dependency:
+
+```bash
+python -m pip install agent-framework-core "mcp>=1.24,<2"
+```
+
+Save the following as `parallel-mcp-example.py` and run `python parallel-mcp-example.py`. It calls the tools directly, so no model credentials or model API calls are needed.
+
+```python
+import asyncio
+from uuid import uuid4
+
+from agent_framework import MCPStreamableHTTPTool
+
+
+async def main():
+    # Reuse one identifier for the related search and fetch calls.
+    session_id = str(uuid4())
+    async with MCPStreamableHTTPTool(
+        name="parallel-search",
+        url="https://search.parallel.ai/mcp",
+        load_prompts=False,
+        request_timeout=60,
+    ) as web:
+        print("Available tools:", [tool.name for tool in web.functions])
+
+        search = await web.call_tool(
+            "web_search",
+            objective="Find Microsoft's introduction to AI agents.",
+            search_queries=["Microsoft Learn what are AI agents"],
+            session_id=session_id,
+        )
+        for content in search:
+            if content.type == "text":
+                print(content.text)
+
+        page = await web.call_tool(
+            "web_fetch",
+            urls=["https://learn.microsoft.com/agent-framework/"],
+            objective="Explain what Agent Framework does.",
+            session_id=session_id,
+        )
+        for content in page:
+            if content.type == "text":
+                print(content.text)
+
+
+asyncio.run(main())
+```
+
+The output lists `web_search` and `web_fetch`, followed by search results and page excerpts. Results can change as the web changes. Compare the tool descriptions and required inputs, then inspect the returned source URLs. If the service returns a rate-limit error, wait before trying again.
+
+The `async with` block initializes the connection, discovers the tools, and closes the connection when finished. To use the same connection with the agent above, pass `tools=[web]` when creating the agent inside that block. The agent can then choose to call the tools during its work, sending its chosen queries, URLs, and context to Parallel. Your model provider still requires its own credentials and may charge for model calls. Remove `web` from the agent's tools to disable that access. See the [framework's MCP guide](https://learn.microsoft.com/agent-framework/agents/tools/local-mcp-tools?WT.mc_id=academic-105485-koreyst) for more options.
+
 ### Multi-agent workflows
 
 Where the framework really stands out is orchestrating several agents together. For example, you can run agents one after another (each passing its context to the next) or fan out to several agents in parallel and aggregate their results:


### PR DESCRIPTION
Lesson 17 teaches how agents use tools through Microsoft Agent Framework. It shows a local weather function and mentions Model Context Protocol (MCP), where a remote server describes its tools and the inputs they accept, but it has no runnable MCP example.

This adds an optional exercise using the framework's `MCPStreamableHTTPTool` to connect to Parallel, discover `web_search` and `web_fetch`, search for Microsoft's introduction to agents, and extract text from the Agent Framework documentation. Learners can see the inputs and results without model credentials or a model API call. The framework handles connection setup and cleanup.

There is no automatically enabled web-search provider or existing search MCP configuration to replace. [Lesson 21's Brave example](https://github.com/microsoft/generative-ai-for-beginners/blob/645f932514e9f22f688c8feb3e49a7a7f2eb6f1b/21-meta/README.md#native-function-calling) only prints a proposed tool call; readers still have to implement the search function.

Parallel's research-task results are a reason to make it easy to try here. On [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api#details), DeepSearchQA measures how well a search-enabled agent answers research questions, using F1 across 900 tasks. These are the displayed scores from its August 31, 2026 data, checked September 4. For each competitor, the table uses its highest-scoring listed configuration on this benchmark; select all providers on the leaderboard to see every row.

| Search API configuration | DeepSearchQA F1 / 100 |
| --- | ---: |
| Parallel Advanced | 81 |
| Perplexity Medium / High | 81 |
| Parallel Fast | 80 |
| Brave LLM context | 78 |
| Exa Auto | 78 |
| You.com Highlights | 77 |
| Firecrawl Search | 74 |
| Tavily Basic | 74 |
| Keenable Pro / Realtime | 70 |
| TinyFish Web | 67 |

Parallel Advanced shares the highest displayed score, and Fast scores above seven of the eight other providers. Fast also has the lowest reported [time per task](https://artificialanalysis.ai/agents/search-api#latency) across all 19 configurations, at 19.4 seconds. That combines derived model time with measured search time, rather than measuring a single search request.

The distinction matters here: [anonymous Search MCP uses Fast](https://docs.parallel.ai/integrations/mcp/search-mcp), not Advanced. These are API results from Artificial Analysis's fixed agent harness, not a benchmark of this example. Perplexity leads the overall Search Index, so the evidence supports trying Parallel for research quality and speed, not claiming it wins every workload. See [the methodology](https://artificialanalysis.ai/methodology/search-api) for the setup.

Running the exercise sends its queries, URLs, objectives, and session identifier to Parallel. Free access is rate limited. The lesson explains how to attach the connection to an agent, which can then choose when to use it; model-provider credentials and charges still apply.

Validation: the exact snippet discovered both tools and returned search and fetch results without credentials, using Python 3.12, `agent-framework-core` 1.17.0, and `mcp` 1.29.1. Ruff and static Markdown checks passed. The original two documentation links returned HTTP 200, though the external-link checker reported network warnings. No repository build or model-driven agent run was performed. The welcome workflow failed on reviewer assignment; the CLA check is pending.

I work at Parallel, which operates this service.
