### PR TITLE
[Lesson 17] Give the Agent Framework agent tools from an MCP server

### DIFF
--- a/17-ai-agents/README.md
+++ b/17-ai-agents/README.md
@@ -154,6 +154,35 @@ async def main():
 asyncio.run(main())
 ```
 
+**MCP tools** - `get_weather` is a function you wrote, so the agent can only do what your own code does. To give it a capability you did not implement, such as searching the web, connect it to a Model Context Protocol (MCP) server. The server publishes its tools with descriptions and input schemas, `MCPStreamableHTTPTool` turns them into agent tools, and the model decides during the run whether and when to call them. This example uses [Keenable](https://keenable.ai), a hosted web search server that is free to use without an account and is rate limited per IP:
+
+```python
+import asyncio
+
+from agent_framework import Agent, MCPStreamableHTTPTool
+from agent_framework.openai import OpenAIChatClient
+
+
+async def main():
+    async with MCPStreamableHTTPTool(
+        name="web",
+        url="https://api.keenable.ai/mcp",
+    ) as web:
+        agent = Agent(
+            client=OpenAIChatClient(),
+            instructions="You are a research assistant. Search the web when you need current information and cite your sources.",
+            tools=[web],
+        )
+
+        response = await agent.run("What is new in the latest Microsoft Agent Framework release?")
+        print(response)
+
+
+asyncio.run(main())
+```
+
+The `async with` block connects to the server, discovers its tools (`search_web_pages` and `fetch_page_content`) and closes the connection when the agent is done. When you run it, the reply is based on the pages the agent searched and read rather than on the model's training data alone, and a question the model can answer by itself usually completes without a tool call. MCP support needs the `mcp` package next to the framework (`pip install mcp`). Your query and any URLs the agent fetches are sent to the server, so use it with public information. See [MCP tools in Agent Framework](https://learn.microsoft.com/agent-framework/agents/tools/local-mcp-tools?WT.mc_id=academic-105485-koreyst) for local servers and authentication options.
+
 To connect to Azure OpenAI in Microsoft Foundry instead, pass your endpoint and credentials to the client:
 
 ```python


### PR DESCRIPTION
Lesson 17 introduces tools in Microsoft Agent Framework with a hand-written `get_weather` function and mentions in passing that the framework also supports MCP servers, but there is no example of that. This adds one short paragraph and a sample right after the `get_weather` example: the same `Agent(...)` call with an `MCPStreamableHTTPTool` in `tools=[...]`, so the agent itself can search the web and decides during the run whether to call the tool.

The MCP server in the sample is Keenable's hosted web search (`https://api.keenable.ai/mcp`), which works over Streamable HTTP without an account or API key and is rate limited per IP, so readers can run the sample with only their model credentials. I work at Keenable. The paragraph says what data is sent to the server and links to the framework's MCP guide for local servers and authentication.

Checked:

- `MCPStreamableHTTPTool(name=..., url=...)` and `Agent(client=..., instructions=..., tools=[...])` match the current `agent-framework-core` (1.17.0) signatures and the framework's MCP documentation.
- The MCP part of the sample was run live against the server: the tool object connects, lists `search_web_pages` and `fetch_page_content`, and a `search_web_pages` call returns results.
- All five markdown link checks from `validate-markdown.yml` pass locally on the changed file (`markdown-checker`); the new learn.microsoft.com link carries the `WT.mc_id` tracking id and no locale.
- One file changed, 29 lines added, no translations touched.
