### PR TITLE
drift scan: gpt-4o pin, 5 critical, 8 warning findings

### DIFF
--- a/.github/workflows/drift-scan.yml
+++ b/.github/workflows/drift-scan.yml
@@ -1,0 +1,18 @@
+# fail-on is empty on purpose: this job annotates findings and never fails CI.
+name: Drift scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 6 * * 1"
+
+jobs:
+  drift-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: 710git/course-drift-oracle@v1
+        with:
+          fail-on: ""


### PR DESCRIPTION
Scanned commit `645f932514e9f22f688c8feb3e49a7a7f2eb6f1b` of this repo with `drift_scan.py` (offline mode, catalog version 2026-08-28b): 102 files, 20 findings (5 critical, 8 warning, 7 info).

## Critical (5)

- `.github/skills/azure-openai-to-responses/references/cheat-sheet.md:70` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `04-prompt-engineering-fundamentals/python/aoai-assignment.ipynb:31` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `04-prompt-engineering-fundamentals/python/githubmodels-assignment.ipynb:29` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `04-prompt-engineering-fundamentals/python/oai-assignment.ipynb:31` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `shared/python/env_utils.py:86` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule

## Warnings (showing 5 of 8)

- `08-building-search-applications/scripts/transcript_enrich_bucket.py:43` - `gpt-4o-mini` is **deprecated** in the catalog, earliest retirement 2027-04-14. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `09-building-image-applications/requirements.txt:1` - `python-dotenv` has no version constraint in this requirements file (status: unpinned).
- `09-building-image-applications/requirements.txt:2` - `openai` has no version constraint in this requirements file (status: unpinned).
- `09-building-image-applications/requirements.txt:3` - `pillow` has no version constraint in this requirements file (status: unpinned).
- `09-building-image-applications/requirements.txt:4` - `requests` has no version constraint in this requirements file (status: unpinned).

## What happens on the retirement date

A deprecated id keeps serving until its retirement date, then every request against it starts failing.

## Optional

```yaml
- uses: 710git/course-drift-oracle@v1
```

Runs this same scan in CI on every push; a retired id fails the job and every finding is annotated at its file and line in the pull request.

This pull request goes one step further than that line and sets `fail-on: ""` in the workflow it adds, which turns the gate off completely so the job only annotates and always passes, whatever it finds; set `fail-on: critical` (the Action's own default, or `warning`, or `info`) in `.github/workflows/drift-scan.yml` whenever you want a finding to fail the build instead.
